### PR TITLE
Resolve some NU1608 warnings in the functions-assembly-loading-catalog

### DIFF
--- a/ReferenceMicrosoftDevices/ReferenceMicrosoftDevices/ReferenceMicrosoftDevices.csproj
+++ b/ReferenceMicrosoftDevices/ReferenceMicrosoftDevices/ReferenceMicrosoftDevices.csproj
@@ -4,8 +4,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Devices" Version="1.6.1" />
-    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="1.0.13" />
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
+    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />

--- a/ReferenceMicrosoftDevices/ReferenceMicrosoftDevices_v2/ReferenceMicrosoftDevices_v2.csproj
+++ b/ReferenceMicrosoftDevices/ReferenceMicrosoftDevices_v2/ReferenceMicrosoftDevices_v2.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Devices" Version="1.16.0-preview-004" />
-    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="1.0.13" />
+    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.0" />
   </ItemGroup>
   <ItemGroup>
     <None Update="host.json">

--- a/ReferenceNewerJsonNet/ReferenceNewerJsonNet/ReferenceNewerJsonNet.csproj
+++ b/ReferenceNewerJsonNet/ReferenceNewerJsonNet/ReferenceNewerJsonNet.csproj
@@ -3,8 +3,8 @@
     <TargetFramework>net461</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="1.0.8" />
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
+    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />

--- a/ReferenceNewerStorageSDK/ReferenceNewerStorageSDK/ReferenceNewerStorageSDK.csproj
+++ b/ReferenceNewerStorageSDK/ReferenceNewerStorageSDK/ReferenceNewerStorageSDK.csproj
@@ -3,9 +3,9 @@
     <TargetFramework>net461</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="1.0.6" />
-    <PackageReference Include="Newtonsoft.Json" Version="11.0.1" />
-    <PackageReference Include="WindowsAzure.Storage" Version="9.0.0" />
+    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
+    <PackageReference Include="WindowsAzure.Storage" Version="9.3.1" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />

--- a/ReferenceNuGetRequiringBindingRedirect/ReferenceNuGetRequiringBindingRedirect/ReferenceNuGetRequiringBindingRedirect.csproj
+++ b/ReferenceNuGetRequiringBindingRedirect/ReferenceNuGetRequiringBindingRedirect/ReferenceNuGetRequiringBindingRedirect.csproj
@@ -4,7 +4,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.0.22" />
-    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="1.0.8" />
+    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.0" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />

--- a/ReferenceProjectThatDependsOnNewerJsonNet/NetStandardClassLibraryUsingNewerJsonNet/NetStandardClassLibraryUsingNewerJsonNet.csproj
+++ b/ReferenceProjectThatDependsOnNewerJsonNet/NetStandardClassLibraryUsingNewerJsonNet/NetStandardClassLibraryUsingNewerJsonNet.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
   </ItemGroup>
 
 </Project>

--- a/ReferenceProjectThatDependsOnNewerJsonNet/ReferenceProjectThatDependsOnNewerJsonNet/ReferenceProjectThatDependsOnNewerJsonNet.csproj
+++ b/ReferenceProjectThatDependsOnNewerJsonNet/ReferenceProjectThatDependsOnNewerJsonNet/ReferenceProjectThatDependsOnNewerJsonNet.csproj
@@ -3,8 +3,8 @@
     <TargetFramework>net461</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="1.0.8" />
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
+    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\NetStandardClassLibraryUsingNewerJsonNet\NetStandardClassLibraryUsingNewerJsonNet.csproj" />


### PR DESCRIPTION
Hi, I found some NU1608 warnings in the functions-assembly-loading-catalog:

`Warning NU1608 Detected package version outside of dependency constraint: Microsoft.NET.Sdk.Functions 1.0.13 requires Newtonsoft.Json (= 9.0.1) but version Newtonsoft.Json 10.0.3 was resolved.`

This fix can remove this warnings from functions-assembly-loading-catalog's dependency graph.
Hope the PR can help you.

Best regards,
sucrose